### PR TITLE
Use GitHub Actions to automatically generate PDFs

### DIFF
--- a/.github/workflows/generate-pdfs.yml
+++ b/.github/workflows/generate-pdfs.yml
@@ -1,0 +1,45 @@
+name: Generate PDFs from TeX
+on:
+  push:
+    paths:
+      - '**/*.tex'
+
+permissions:
+  contents: write
+
+jobs:
+  generate-pdfs:
+    name: Generate PDFs
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Gather changed TeX files
+        id: changed-files
+        uses: tj-actions/changed-files@v37
+        with:
+          files: '**/*.tex'
+          separator: "\n"
+
+      - name: (Hack) Use EB Garamond instead of Garamond
+        run: |
+          shopt -s globstar
+          sed -i 's/\\setmainfont{Garamond}/\\usepackage[lining,tabular]{ebgaramond}/' **/*.tex
+
+      - name: Compile TeX documents
+        uses: xu-cheng/latex-action@v2
+        with:
+          root_file: ${{ steps.changed-files.outputs.all_changed_files }}
+          work_in_root_file_dir: true
+          latexmk_use_xelatex: true
+
+      - name: Commit and push PDFs
+        run: |
+          shopt -s globstar
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add **/*.pdf
+          git commit -m "Generate PDFs from commit $GITHUB_SHA"
+          git push

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.out
+*.aux
+*.log
+*.toc
+*.vs*


### PR DESCRIPTION
This one YAML file took 8 hours.

By merging this PR, whenever someone pushes a commit (including in a pull request, or by merging one), any `.tex` files that were changed will have their corresponding PDFs rebuilt, including table of contents and other information that requires multiple XeLaTeX passes.

This does mean that if you generate and commit the PDF yourself, it will be overwritten. I think this is fine, and even desired since the environment in which you generated it may not be consistent with what the action uses.