### PR TITLE
Make "Board Representative" a separate role with ex-officio Board seats

### DIFF
--- a/bylaw-1.md
+++ b/bylaw-1.md
@@ -16,7 +16,7 @@ subtitle: The Engineering Society
 ## Interpretation
 1. In this document:
    1. "Constituencies" shall mean the divisions of the student body, defined by both year and discipline, as well as the PEY Constituency and the TrackOne class;
-   1. "Board Members" shall mean members of the Board of Directors, as specified in Chapter 4;
+   1. "Board Members" shall mean Directors of the Board, as specified in Chapter 4;
    1. "Faculty" shall mean the Faculty of Applied Science and Engineering of the University of Toronto;
    1. "Governing Council" shall mean the Governing Council of the University of Toronto;
    1. "Officers" shall mean the President and all Vice-Presidents of the Society, as specified in Chapter 3;
@@ -206,42 +206,41 @@ subtitle: The Engineering Society
 
 ## General
 1. The business and affairs of the Society shall be managed by a Board of Directors.
+1. The the following office-holders, by virtue of their office in accordance with Section 23(4) of ONCA, shall be the Directors of the Board:
+   1. The five (5) EngSoc Officers defined in Chapter 3;
+   1. The sixteen (16) Board Representatives defined in section 4.1; and
+   1. The Speaker (as defined in section 4.6), as a non-voting director.
 
-## Directors of the Board
-1. The Board shall be comprised of all:
-   1. The Five (5) Officers of the Engineering Society;
-   1. Nine (9) Discipline Representatives as follows:
-      1. Chemical Engineering Representative;
-      1. Civil Engineering Representative;
-      1. Two (2) Electrical and Computer Engineering Representatives;
-      1. Engineering Science Representative;
-      1. Industrial Engineering Representative;
-      1. Materials Science and Engineering Representative;
-      1. Mechanical Engineering Representative;
-      1. Mineral Engineering Representative;
-   1. Three (3) Representatives from First Year;
-   1. Four (4) At-Large Representatives, representing the Society At-Large; and
-1. All Directors of the Board must meet the following criteria when their respective term of office begins, as described in Section 4.2.
-   1. Must be at least 18 years of age.
-   1. Must not have been found under the Substitute Decisions Act, 1992 or under the Mental Health Act to be incapable of managing property.
-   1. Must not have been found to be incapable by any court in Canada or elsewhere.
-   1. Must not be bankrupt.
+## Board Representatives
+1. There shall be nine (9) Discipline Representatives, each elected by Members in their respective Discipline, as follows:
+   1. One (1) Chemical Engineering Board Representative;
+   1. One (1) Civil Engineering Board Representative;
+   1. Two (2) Electrical and Computer Engineering Board Representatives;
+   1. One (1) Engineering Science Board Representative;
+   1. One (1) Industrial Engineering Board Representative;
+   1. One (1) Materials Science and Engineering Board Representative;
+   1. One (1) Mechanical Engineering Board Representative; and
+   1. One (1) Mineral Engineering Board Representative.
 1. Discipline Representatives are responsible for providing updates and raising concerns, as necessary, between their respective Discipline Clubs and the Board of Directors. The primary contact for the Representative in question will be their respective Discipline Club Chair, unless otherwise determined by the Discipline Club.
+1. There shall be three (3) First Year Board Representatives, elected by Members in First Year.
+1. There shall be four (4) At-Large Board Representatives, elected by Members at large.
+1. Election as mentioned in the above section shall be in accordance with section 4.2 and [Bylaw 3](bylaw-3.md).
+1. All Board Representatives must be, at all times throughout their term, EngSoc Members who meet the criteria specified in Section 23(1) of ONCA.
 
 ## Elections and Term of Office
 1. The results of any election held by the Society shall become official when they are ratified by a general resolution of the Board.
 1. The Board shall not refuse to ratify the results of an election conducted in accordance with the Bylaws of the Society.
-1. Each Board member’s term of office shall begin at the adjournment of the April Board of Directors meeting.
-   1. Within 10 days of being elected, each Board Member must sign a written letter attesting their consent to act as a Director of the Society.
-1. The term of the First Year Representative position extends until the adjournment of the Board of Directors meeting ratifying the election of their successor.
-1. A Member of the Board of Directors may resign from their position at any point during their term by giving formal written notice to the Vice President Communications and Speaker.
-   1. Notwithstanding Section 27 of ONCA, the Society is not required to provide Members with a statement written by a Member of The Board of Directors.
+1. Incoming Discipline Representatives and At-Large Representatives shall take office, and the term of office of their predecessors ends, at the adjournment of the April Board of Directors meeting.
+1. Incoming First Year Representatives shall take office, and the term of office of their predecessors ends, at the adjournment of the Board of Directors meeting ratifying the Fall elections.
+1. Board Representatives elected during a by-election take office immediately upon the ratification of the by-election.
+1. A Board Representative may resign from their position at any point during their term by giving formal written notice to the Vice President Communications and/or Speaker.
+   1. Notwithstanding Section 27 of ONCA, the Society is not required to provide Members with a statement written by a Director of the Board.
 1. No Member of the Society may hold more than one (1) position on the Board of Directors at any given time.
-1. If a seat on the Board of Directors is left vacant after the Board of Directors Election Period and prior to the First Year Board of Directors Election Period as defined in [Bylaw 3](bylaw-3.md), the Chief Returning Officer shall hold an election in accordance with the relevant sections of [Bylaw 3](bylaw-3.md).
+1. The Chief Returning Officer shall call a by-election in every month during which a Board Representative position is vacant, if at least four (4) months remain before the end of the term of the position, and except as otherwise prohibited by the Bylaws.
 
 ## Votes and Quorum
 1. Each Board Member shall have one (1) vote on each motion to be decided by the Board.
-1. Quorum of the Board shall be a majority of the members of the Board.
+1. Quorum of the Board shall be a majority of the Directors of the Board.
 
 ## Indemnity
 1. Every Board Member and their heirs, executors and administrators, and estate and effects, respectively shall be indemnified and saved harmless out of the funds of the Society, from and against:
@@ -254,7 +253,7 @@ subtitle: The Engineering Society
 ## Speaker
 1. The Speaker shall act as Chair of the Board of Directors and shall ensure proper procedure during all meetings of the Board.
 1. In the absence of the Speaker, the President shall act as Chair of the Board, except as determined by a majority vote of the Board.
-1. The Speaker shall be a non-voting member of the Board of Directors.
+1. The Speaker shall be a non-voting Director of the Board.
 1. All decisions of the Speaker may be reversed by a two-thirds majority vote of the Board, except regarding applicable law, the Constitution and Bylaws of the Society from which there is no appeal.
 1. In addition to the responsibilities outlined above, the Speaker shall also fulfill the duties specified in [Bylaw 2, Section 3.1](bylaw-2.md).
 
@@ -280,7 +279,7 @@ subtitle: The Engineering Society
 ## Special Meetings
 1. The Speaker may call a Special Meeting of the Board of Directors with a notice of twenty-four (24) hours provided the purpose of the meeting warrants immediate disposition.
    1. The President may also call a Special Meeting of the Board of Directors with a notice of twenty-four (24) hours in the absence of the Speaker or if the purpose of the meeting is to recall the Speaker.
-1. A Special Meeting of the Board of Directors may also be called by submitting a petition to the Speaker that is signed by at least one-half of all members of the Board.
+1. A Special Meeting of the Board of Directors may also be called by submitting a petition to the Speaker that is signed by at least one-half of all Directors of the Board.
    1. The petition must specify the purpose of the meeting and no other business may be conducted at the Special Meeting.
    1. The Speaker must call a meeting within seven (7) days of receiving a valid petition.
 
@@ -295,22 +294,21 @@ subtitle: The Engineering Society
 1. Minutes shall indicate each voting member's vote on each motion, whether in favour, against, or in abstention.
 
 ## Recall
-1. A Member of the Board of Directors shall be automatically recalled upon cessation of their membership of the constituency or constituencies that elected them.
-1. A Member of the Board of Directors, except Officers, may only be recalled by a simple majority of one of the following, in which only the Member's constituency or constituencies are eligible to vote:
-   1. A successful referendum for that purpose, if called for reason of breaching the standard of conduct in section 4.11.3; or
-   1. A simple majority vote at a General Meeting called for that purpose.
-1. A Member of the Board of Directors, including Officers, shall adhere to a standard of conduct that includes the following:
-   1. A Member of the Board of Directors shall not be absent from more than two (2) regular meetings of the Board of Directors without regrets over the course of their term.
-   1. A Member of the Board of Directors shall not be absent from more than three (3) regular meetings of the Board of Directors over the course of their term.
-1. If a Member of the Board of Directors breaches the standard of conduct outlined in section 4.11.3, the Speaker shall submit a motion at the next monthly meeting of the Board of Directors following the breach of conduct to begin the process of recalling the Member in question. The Member in question will have the opportunity to defend their breach of conduct at the meeting of the Board of Directors in which the motion is submitted by the Speaker.
+1. A Board Representative shall be automatically recalled upon cessation of their membership of the constituency or constituencies that elected them.
+1. A Board Representative may only be recalled:
+   1. by a successful referendum in accordance with [Bylaw 3, section 6.3](bylaw-3.md);
+   1. by a simple majority vote at a General Meeting called for that purpose, in which only the Representative's constituency is eligible to vote; or
+   1. by a vote of the Board with at most two (2) dissenting votes, if a referendum cannot legally be called.
+1. All Directors of the Board shall adhere to a standard of conduct that includes the following:
+   1. A Director of the Board shall not be absent from more than two (2) regular meetings of the Board of Directors without regrets over the course of their term.
+   1. A Director of the Board shall not be absent from more than three (3) regular meetings of the Board of Directors over the course of their term.
+1. If a voting Director of the Board breaches the standard of conduct outlined in section 4.11.3, the Speaker shall submit a motion at the next monthly meeting of the Board of Directors following the breach of conduct to begin the process of recalling the Member in question. The Member in question will have the opportunity to defend their breach of conduct at the meeting of the Board of Directors in which the motion is submitted by the Speaker.
    1. For an Officer, the motion shall be to call a General Meeting for the purpose of recalling the Officer.
-   1. For any other Member of the Board of Directors, the motion shall be to call a referendum for the purpose of recalling the Member.
-1. A Member of the Board of Directors’ failure to meet the standard of conduct outlined in section 4.11.3 may be neglected if the Member of the Board of Directors’ circumstances are proven to be extraneous or due to other factors, at the discretion of the Speaker.
+   1. For a Board Representative, the motion shall be in accordance with section 4.11.2.
+1. A Director of the Board's failure to meet the standard of conduct outlined in section 4.11.3 may be neglected if their circumstances are proven to be extraneous or due to other factors, at the discretion of the Speaker.
    1. The Speaker shall inform the Board of Directors any time a failure to meet the standard of conduct is neglected.
-   1. A Member of the Board of Directors may request additional information from the Speaker about the Speaker’s decision to neglect a failure to meet the standard of conduct.
-   1. If any personal information must be disclosed in order for the Speaker to meet the request of a Member of the Board of Directors described in section 4.11.5b, the Speaker must gain permission from the person whose information will potentially be disclosed.
-   1. If such permission is granted, a motion must be submitted to move the meeting to an in camera session before the Speaker may meet the Member’s request.  If permission is not granted, the Member’s request as described in section 4.11.5b will not be fulfilled.
-1. In all other situations not specified in section 4.11.3, upon a resolution to recall a Member of the Board of Directors, the Chief Returning Officer shall hold a General Meeting as specified in section 4.11.2.
+   1. A Director of the Board may request additional information from the Speaker about the Speaker’s decision to neglect a failure to meet the standard of conduct.
+   1. If any personal information must be disclosed in order for the Speaker to meet such a request, the Director of the Board whose information will potentially be disclosed may require that it be disclosed _in camera_.
 
 ## Committees
 1. The following shall be considered Standing Committees of the Board:
@@ -325,15 +323,15 @@ subtitle: The Engineering Society
 1. The Finance Committee shall consist of the Vice-President Finance, the Vice-President Student Life and other members as the Board may appoint.
    1. The Vice-President Finance shall serve as the Chair of the Finance Committee; and
    1. The Vice-President Finance shall strike the Finance Committee no later than at the May Board of Directors Meeting.
-1. The Policy and Structures Committee shall shall consist of the President, the Vice-President Communications, the CRO (as defined in [Bylaw 3](bylaw-3.md)), the Speaker of the Board, members of the Board as elected, and appointed members of the Society.
+1. The Policy and Structures Committee shall shall consist of the President, the Vice-President Communications, the CRO (as defined in [Bylaw 3](bylaw-3.md)), the Speaker of the Board, Directors of the Board as elected, and appointed members of the Society.
    1. The Vice-President Communications shall fulfill the role of the Chair until such time as the Committee elects its own Chair.
    1. The Vice-President Communications shall strike the Policy and Structures Committee no later than at the May Board of Directors Meeting.
    1. The Policy and Structures Committee will review [Bylaw 3](bylaw-3.md) at their August and November meetings.
-1. The Academic Advocacy Committee shall consist of the Vice-President Academic, other members of the Board that may be appointed, one representative from each Discipline appointed by Discipline Club Chairs, Faculty Council Standing Committee Representatives, Faculty Council Representatives and appointed members of the Society.
+1. The Academic Advocacy Committee shall consist of the Vice-President Academic, other Directors of the Board that may be appointed, one representative from each Discipline appointed by Discipline Club Chairs, Faculty Council Standing Committee Representatives, Faculty Council Representatives and appointed members of the Society.
    1. The Vice-President Academic shall serve as the Chair of the Academic Advocacy Committee; and
    1. The Vice-President Academic shall strike the Academic Advocacy Committee no later than at the May Board of Directors Meeting.
    1. The Academic Advocacy Committee shall meet prior to each Faculty Council meeting of the Academic Year to discuss the agenda items of the Faculty Council meeting.
-1. The Clubs Affiliation Committee shall consist of the Vice-President Student Life, Vice-President Finance, the DTA Director, members of the Board as elected, and appointed members of Society.
+1. The Clubs Affiliation Committee shall consist of the Vice-President Student Life, Vice-President Finance, the DTA Director, Directors of the Board as elected, and appointed members of Society.
    1. The Vice-President Student Life shall serve as the Chair of the Affiliation Committee;
    1. The Affiliation Committee shall have the authority to approve Trial Status applications and Full Status Renewal applications without ratification from the Board of Directors; and
    1. The Vice-President Student Life shall strike the Affiliation Committee no later than at the May Board of Directors Meeting.
@@ -341,14 +339,13 @@ subtitle: The Engineering Society
    1.	The Vice-President Finance shall serve as the Chair of the Audit Committee.
    1. The Vice-President Finance shall strike the Audit Committee no later than at the May Board of Directors Meeting.
    1.	At least two members of the Finance Committee shall also sit on the Audit Committee.
-
 1. No resolution of a Standing Committee shall take force until it is ratified by the Board, unless otherwise specified in these bylaws.
 1. Notice of meetings of Standing Committees of the Board shall be given electronically or in writing to every member who has expressed interest in meetings of that committee at least three (3) days before the time chosen for such a meeting.
 
 ## Conflicts of Interest
 1. The Speaker shall have the authority to bar Board members from voting on a motion where the Member has a conflict of interest.
 1. It shall be out of order for the Board of Directors to vote on motions to approve its own non-essential expenses unless a non-essential expenses quota is approved at a General Meeting of the Society.
-   1. Non-essential expenses include any food or recreational purchases which members of the Board or Council as a whole will have free and exclusive access to.
+   1. Non-essential expenses include any food or recreational purchases which Directors of the Board or Council as a whole will have free and exclusive access to.
    1. A non-essential expenses quota specifies a maximum amount of money which the Board is able to use for non-essential expenses cumulatively until the quota expires.
    1. An active non-essential expenses quota expires immediately after 365 days from when a quota comes into effect or when a new quota comes into effect.
    1. Unused funds from an expired quota do not carry over.

--- a/bylaw-1.md
+++ b/bylaw-1.md
@@ -298,7 +298,7 @@ subtitle: The Engineering Society
 1. A Board Representative may only be recalled:
    1. by a successful referendum in accordance with [Bylaw 3, section 6.3](bylaw-3.md);
    1. by a simple majority vote at a General Meeting called for that purpose, in which only the Representative's constituency is eligible to vote; or
-   1. by a vote of the Board with at most two (2) dissenting votes, if a referendum cannot legally be called.
+   1. by a vote of the Board with at most two (2) dissenting votes, if a referendum cannot legally be called or feasibly called at the discretion of the speaker.
 1. All Directors of the Board shall adhere to a standard of conduct that includes the following:
    1. A Director of the Board shall not be absent from more than two (2) regular meetings of the Board of Directors without regrets over the course of their term.
    1. A Director of the Board shall not be absent from more than three (3) regular meetings of the Board of Directors over the course of their term.

--- a/bylaw-1.md
+++ b/bylaw-1.md
@@ -1,5 +1,5 @@
 ---
-revdate: April 4, 2026
+revdate: June 25, 2026
 title: Bylaw 1
 pdf: Bylaw 1
 subtitle: The Engineering Society

--- a/bylaw-2.md
+++ b/bylaw-2.md
@@ -1,5 +1,5 @@
 ---
-revdate: March 30, 2026
+revdate: June 25, 2026
 title: Bylaw 2
 pdf: Bylaw 2
 subtitle: The Directors, Associated Entities, and Neutral Officers Bylaw

--- a/bylaw-2.md
+++ b/bylaw-2.md
@@ -307,7 +307,7 @@ subtitle: The Directors, Associated Entities, and Neutral Officers Bylaw
 1. The Speaker shall attend a form of or equivalent of Equity Training and Sexual Violence Prevention and Response Training, before the November month of their term, provided by the University of Toronto and their resources or from an external organization deemed reliable at a meeting of the Board of Directors.
 1. The Speaker shall be elected according to the process outlined in [Bylaw 3, Section 5.3](bylaw-3.md)
    1. Following the adjournment of the April Board of Directors Meeting, the Speaker’s term of office shall end but they shall also automatically be appointed as the interim Speaker until the May Board of Directors Meeting.
-   1. The outgoing Speaker is required to call a Special Meeting of the Board of Directors where an alternative interim Speaker may be appointed, if such a request is made before the May Board of Directors Meeting by at least one (1) member of the incoming Board of Directors. The meeting must be called within seven (7) days of having received such a request.
+   1. The outgoing Speaker is required to call a Special Meeting of the Board of Directors where an alternative interim Speaker may be appointed, if such a request is made before the May Board of Directors Meeting by at least one (1) incoming Director of the Board. The meeting must be called within seven (7) days of having received such a request.
    1. The outgoing Speaker is required to inform all incoming Board members of the provisions of Section 3.1.5.b at least seven (7) days before the April Board of Directors Meeting.
 
 ## Chief Returning Officer

--- a/bylaw-3.md
+++ b/bylaw-3.md
@@ -90,8 +90,9 @@ subtitle: The Elections Bylaw
 1. The Nomination Period for the election of Officers shall commence at 9:00 am on the Monday before Reading Week of the Winter semester, and shall close at 5:00 pm on the Friday of Reading Week.
 1. A Member shall be considered nominated upon submitting a completed Nomination Package to the Engineering Society Office, no later than the close of the Nomination Period, which shall include:
    1. The Member's name, student number, contact information, and signature;
-   1. The names, student numbers, and signatures of twenty-five (25) Nominators, all of whom shall be Members; and
-   1. A fifty dollar ($50) cash deposit.
+   1. The names, student numbers, and signatures of twenty-five (25) Nominators, all of whom shall be Members;
+   1. A fifty dollar ($50) cash deposit; and
+   1. A letter in accordance with Section 24(8) of ONCA attesting their consent to act as a director of the corporation if elected.
 1. Potential candidates must submit a voter's statement, through a means specified by the Nomination Package, which is due at the close of the Nomination Period.
    1. The voter's statement must have at least one (1) word, and is limited to two-hundred and fifty (250) words in length, in accordance with section 8.0.7.
 1. The CRO shall produce a certified list of candidates within seventy-two (72) hours from the close of the Nomination Period.

--- a/bylaw-3.md
+++ b/bylaw-3.md
@@ -150,8 +150,9 @@ subtitle: The Elections Bylaw
 1. A Member who currently holds a seat on the Board of Directors may not seek another seat with the same term without first resigning their current seat.
 1. Members shall not be nominated for more than one (1) Board of Directors position.
 1. A Member shall be considered nominated upon submitting a completed Nomination Package to the Engineering Society Office, no later than the close of the Nomination Period, which shall include:
-   1. The Member's name, student number, contact information, and signature; and
-   1. The names, student numbers, and signatures of ten (10) Nominators, all of whom shall be from the same constituency represented by the Director position.
+   1. The Member's name, student number, contact information, and signature;
+   1. The names, student numbers, and signatures of ten (10) Nominators, all of whom shall be from the same constituency represented by the Director position; and
+   1. A letter in accordance with Section 24(8) of ONCA attesting their consent to act as a director of the corporation if elected.
 1. The Campaign Period shall:
    1. Commence between twenty four (24) and seventy-two (72) hours after the ACM; and
    1. Be between two (2) and three (3) business days (inclusive) in length.
@@ -272,11 +273,11 @@ subtitle: The Elections Bylaw
       1. The outgoing Speaker will remain on the hiring committee even if they are not serving as the interim Speaker at the time.
    1. One of: the outgoing CRO, Chair of the Policy and Structures Committee or Ombudsperson;
    1. One of: the outgoing President, Vice-President Finance or Vice-President Communications;
-   1. One (1) member of the outgoing Board of Directors;
-   1. One (1) member of the incoming Board of Directors.
+   1. One (1) outgoing Director of the Board;
+   1. One (1) incoming Director of the Board.
 1. If one or more positions on the hiring committee remain vacant after exhausting all options, the CRO may select available individuals from the other brackets.
 1. The hiring committee shall follow the interview process outlined in Sections 7.2.4, 7.2.5, 7.2.6, and 7.2.7.
-1. At the May Board of Directors Meeting, each candidate will have the opportunity to speak for two (2) minutes on their candidacy for the position and chair a mock meeting held during recess. The agenda for the mock meeting will be prepared by the interim Speaker. Each member of the Board shall have one (1) vote to elect the Speaker at the meeting.
+1. At the May Board of Directors Meeting, each candidate will have the opportunity to speak for two (2) minutes on their candidacy for the position and chair a mock meeting held during recess. The agenda for the mock meeting will be prepared by the interim Speaker.
 1. Other details of the elections shall be at the discretion of the CRO.
 
 # Referenda
@@ -328,7 +329,7 @@ subtitle: The Elections Bylaw
 1. Such a referendum which receives votes from at least 5% of Members in the constituency in question, of which a simple majority are in favor, shall lead to the Class Representative being recalled. Otherwise, the referendum fails.
 
 ## Referenda to Recall a Board Representative
-1. A referendum to recall a Member of the Board of Directors, except Officers, for reason of breaching the standard of conduct in [Bylaw 1 section 4.11.3](bylaw-1.md) must be called by a simple majority vote at a Board of Directors Meeting.
+1. A referendum to recall a Board Representative, as defined in [Bylaw 1 section 4.1](bylaw-1.md), for reason of breaching the standard of conduct in [Bylaw 1 section 4.11.3](bylaw-1.md) must be called by a simple majority vote at a Board of Directors Meeting.
 1. The question text of such a referendum shall be: "Do you support recalling [name] from their position as [constituency] Board Representative?" where "[name]" is the name of the Board Representative in question and "[constituency]" is the constituency they represent (e.g. "At-Large", "First Year").
 1. The voting period for such a referendum shall begin at most eleven (11) business days after it is called, at the CRO's discretion, and shall last at least three (3) days. If possible within these constraints, the voting period shall be aligned with the voting period of any other ongoing election cycle.
 1. There shall be no campaigning for such a referendum. Campaigning in any form by either the party calling the referendum or the Board Representative in question, beyond the voter statements outlined below, will result in a warning to the campaigning party, in accordance with Section 9.1.
@@ -361,13 +362,13 @@ subtitle: The Elections Bylaw
    1. The outgoing overseeing Officer;
    1. Two (2) Project Director(s), Internal Representative(s), or Discipline Club Chair(s).
 1. Unless otherwise specified in Bylaw 3, each Project Director Hiring Committee shall include all members from each bracket outlined in Sections 7.2.1.a through 7.2.1.c, and no more than two (2) members selected from Section 7.2.1.d.
-   1. If an insufficient number of members under Section 7.2.1.d are interested in sitting on the hiring committee, their place may be taken by Board Members or Officers as needed, at the discretion of the CRO.
+   1. If an insufficient number of members under Section 7.2.1.d are interested in sitting on the hiring committee, their place may be taken by Board Representatives or Officers as needed, at the discretion of the CRO.
 1. Should the outgoing Officer be unable or unwilling to sit on the hiring committee as per Section 7.2.1.b, their place shall be filled in the following order of precedence:
    1. Any current Member who has previously served in that Officer position.
    1. Any Alumni Member who has previously served in that Officer position within the past 4 years.
    1. Any outgoing Project Director who served under the outgoing Officer.
    1. Any other outgoing Officer.
-   1. Members of the outgoing Board of Directors.
+   1. Outgoing Board Members.
 1. At the request of the hiring committee, the CRO may allow up to two (2) Members (including Alumni Members) specified by the hiring committee to participate as non-voting members of the committee.
 1. The hiring committee shall interview all nominees and minute each interview's questions and answers.
    1. If requested by the candidate, one member of the hiring committee must record the entire interview. The candidate may choose to make this recording available to the Board of Directors.
@@ -378,7 +379,7 @@ subtitle: The Elections Bylaw
    1. Should the number of candidates elected be greater than zero, but less than the number of positions available, nominations shall be reopened only for the unfilled positions, unless the smaller number of candidates elected is permitted for the position as specified in [Bylaw 2](bylaw-2.md). For example, [Bylaw 2](bylaw-2.md) permits only one (1) Orientation Chair to be elected, despite two (2) positions being available.
 
 ## Board Meeting
-1. Each recommendation report shall be circulated to Members of the Board of Directors and candidates as soon as is reasonably possible.
+1. Each recommendation report shall be circulated to the Board of Directors and candidates as soon as is reasonably possible.
    1. Any recommendation report must be available to the parties listed in Section 7.3.1 at least 48 hours prior to the scheduled start of the Board of Directors meeting ratifying it.
    1. At least one member of each hiring committee must be present at the Board meeting to motivate their respective recommendation report and answer questions from the Board.
    1. Any position for which the associated recommendation report was not presented to the Board in accordance with the requirements in Section 7.3.1.a and Section 7.3.1.b shall not be elected, and the motion to elect the position shall be tabled until the next meeting of the Board of Directors.
@@ -492,8 +493,7 @@ subtitle: The Elections Bylaw
    1. A person may not serve as a Campaign Assistant for more than one candidate in the same election cycle.
 1. Campaign Assistants must be Members.
 1. Campaign Assistants may not be:
-   1. Members of the EngSoc Board of Directors
-   1. EngSoc Officers
+   1. EngSoc Board Members, including Officers
    1. UTSU Executives
    1. Candidates for positions for which Campaign Assistants are permitted in the same election cycle (e.g. elected positions)
    1. The incumbent in the role for which their candidate is running
@@ -567,8 +567,8 @@ subtitle: The Elections Bylaw
 1. The Election Appeals Committee shall report to the Board of Directors all matters brought to them and any recommended action.
 1. The Election Appeals Committee's jurisdiction on any appeal shall be limited to the election(s) which the appeal concerns.
 1. The Election Appeals Committee (EAC) shall consider those arguments submitted to them by the Office of Returning Officers (ORO) and the appellant. Other relevant parties, as determined by the EAC, may be given reasonable opportunity to submit additional arguments and evidence.
-1. Any ruling of the Election Appeals Committee that upholds the ruling of the CRO in part or in full, or grants the requests of the appellant in part or in full shall be binding, unless opposed by a fourth-fifths majority vote of the Board, with at least a simple majority of the total membership of the Board voting to oppose. Members of the Election Appeals Committee and other members of the Board barred from voting by the Speaker will not be included in the total membership count.
-   1. In the event the four-fifths threshold falls below the simple majority of the total membership of the Board due to absence of members of the Board, the Speaker shall table the motion to a special meeting where a higher number of Board members may be present.
+1. Any ruling of the Election Appeals Committee that upholds the ruling of the CRO in part or in full, or grants the requests of the appellant in part or in full shall be binding, unless opposed by a fourth-fifths majority vote of the Board, with at least a simple majority of the total membership of the Board voting to oppose. Members of the Election Appeals Committee and other Directors of the Board barred from voting by the Speaker will not be included in the total membership count.
+   1. In the event the four-fifths threshold falls below the simple majority of the total membership of the Board due to absence of Directors of the Board, the Speaker shall table the motion to a special meeting where a higher number of Board members may be present.
 1. Any other ruling of the Election Appeals Committee shall be binding unless opposed by a regular motion of the Board
 1. Any recommendation of the Election Appeals Committee that does not pertain directly to the submitted Appeal, or any ruling beyond its jurisdiction shall not be binding.
 

--- a/bylaw-3.md
+++ b/bylaw-3.md
@@ -1,5 +1,5 @@
 ---
-revdate: April 4, 2026
+revdate: June 25, 2026
 title: Bylaw 3
 pdf: Bylaw 3
 subtitle: The Elections Bylaw

--- a/policies/policy-on-complaints.md
+++ b/policies/policy-on-complaints.md
@@ -14,7 +14,7 @@ subtitle: Policy on Complaints
 1. It is a requirement under the University of Toronto Policy for Compulsory Non-Academic Incidental Fees that organizations receiving such fees have and adhere to an internal process for addressing complaints. Further, the existence and continual refinement of such a process is an organizational best practice that is in the interest of facilitating Member participation in the Society.
 
 ## Application
-1. This policy applies to any Member that holds a position within the Engineering Society, including without limitation, an Officer, Project Director, employee, member of the Board of Directors, member of a Project Director’s team, or member of an Affiliated Club acting in an official capacity for the club.
+1. This policy applies to any Member that holds a position within the Engineering Society, including without limitation, an Officer, Project Director, employee, Board Representative, member of a Project Director’s team, or member of an Affiliated Club acting in an official capacity for the club.
    1. This policy applies to any of the persons listed in section 0.2.1 for the entirety of their term, from when they take office of their position to when they are relieved of their position. This includes actions taken outside of their official capacity within their role.
 1. Complaints to which this policy applies include the misconduct of any Member that holds a position within the Engineering Society as defined in section 0.2.1. This policy defines an act of misconduct as any of the following, as interpreted by the investigator of the case:
    1. any offense outlined in section B1 of the University of Toronto Code of Student Conduct

--- a/policies/policy-on-complaints.md
+++ b/policies/policy-on-complaints.md
@@ -1,5 +1,5 @@
 ---
-revdate: March 30, 2026 by the Board of Directors
+revdate: June 25, 2026 by the Board of Directors
 title: Policy Number "2013-02-01"
 pdf: policies/Policy-on-Complaints
 subtitle: Policy on Complaints


### PR DESCRIPTION
This is required under ONCA; non-_ex officio_ directors can only be elected at a General Meeting, which we're obviously not doing.